### PR TITLE
Filtro de pedidos em andamento e movimentação na fila da cozinha

### DIFF
--- a/project/src/main/java/tech/fiap/project/app/adapter/KitchenMapper.java
+++ b/project/src/main/java/tech/fiap/project/app/adapter/KitchenMapper.java
@@ -2,6 +2,7 @@ package tech.fiap.project.app.adapter;
 
 import tech.fiap.project.app.dto.KitchenDTO;
 import tech.fiap.project.domain.entity.Kitchen;
+import tech.fiap.project.infra.entity.KitchenEntity;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ public class KitchenMapper {
 			KitchenDTO kitchenDTO = new KitchenDTO();
 			kitchenDTO.setOrderId(kitchen.getOrderId());
 			kitchenDTO.setCreationDate(kitchen.getCreationDate());
+			kitchenDTO.setUpdatedDate(kitchen.getUpdatedDate());
 			kitchenDTO.setStatus(kitchen.getStatus());
 			return kitchenDTO;
 		}
@@ -29,8 +31,29 @@ public class KitchenMapper {
 			return null;
 		}
 		else {
-			return new Kitchen(kitchen.getOrderId(), kitchen.getCreationDate(), kitchen.getStatus());
+			return new Kitchen(kitchen.getOrderId(), kitchen.getCreationDate(), kitchen.getUpdatedDate(), kitchen.getStatus());
 		}
 	}
 
+	public static Kitchen toDomain(KitchenEntity kitchen) {
+		if (kitchen == null) {
+			return null;
+		}
+		else {
+			return new Kitchen(kitchen.getOrderId(), kitchen.getCreationDate(), kitchen.getUpdatedDate(), kitchen.getStatus());
+		}
+	}
+
+	public static KitchenEntity toEntity(Kitchen kitchen) {
+		if (kitchen == null) {
+			return null;
+		}
+		else {
+			KitchenEntity kitchenEntity = new KitchenEntity();
+			kitchenEntity.setOrderId(kitchen.getOrderId());
+			kitchenEntity.setCreationDate(kitchen.getCreationDate());
+			kitchenEntity.setStatus(kitchen.getStatus());
+			return kitchenEntity;
+		}
+	}
 }

--- a/project/src/main/java/tech/fiap/project/app/adapter/OrderMapper.java
+++ b/project/src/main/java/tech/fiap/project/app/adapter/OrderMapper.java
@@ -1,17 +1,60 @@
 package tech.fiap.project.app.adapter;
 
 import tech.fiap.project.app.dto.*;
+import tech.fiap.project.domain.entity.Kitchen;
 import tech.fiap.project.domain.entity.Order;
 import tech.fiap.project.domain.entity.Payment;
 import tech.fiap.project.domain.entity.Person;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class OrderMapper {
 
 	public static List<OrderResponseDTO> toDTO(List<Order> orders) {
 		return orders.stream().map(OrderMapper::toDTO).toList();
+	}
+
+	public static List<OrderResponseDTO> toDTO(List<Order> orders, List<Kitchen> kitchens) {
+		return orders.stream().map(order -> {
+			Optional<Kitchen> kitchen = kitchens.stream().filter(_kitchen -> Objects.equals(_kitchen.getOrderId(), order.getId())).findFirst();
+			return toDTO(order, kitchen);
+		}).toList();
+	}
+
+	public static OrderResponseDTO toDTO(Order order, Optional<Kitchen> kitchen) {
+		PersonDTO person = null;
+		if (order.getPerson() != null) {
+			person = PersonMapper.toDTO(order.getPerson());
+		}
+		OrderResponseDTO orderResponseDTO = new OrderResponseDTO();
+		orderResponseDTO.setId(order.getId());
+		orderResponseDTO.setStatus(order.getStatus());
+		orderResponseDTO.setCreatedDate(order.getCreatedDate());
+		;
+		orderResponseDTO.setUpdatedDate(order.getUpdatedDate());
+		orderResponseDTO.setItems(order.getItems().stream().map(item -> {
+			ItemDTO itemDTO = new ItemDTO();
+			itemDTO.setId(item.getId());
+			itemDTO.setQuantity(item.getQuantity());
+			itemDTO.setUnit(item.getUnit());
+			itemDTO.setPrice(item.getPrice());
+			itemDTO.setName(item.getName());
+			itemDTO.setCategory(item.getItemCategory());
+			itemDTO.setIngredients(item.getIngredients().stream().map(ItemMapper::toDTO).toList());
+			itemDTO.setDescription(item.getDescription());
+			itemDTO.setImageUrl(item.getImageUrl());
+			return itemDTO;
+		}).toList());
+		orderResponseDTO
+				.setPayment(order.getPayments().stream().map(payment -> PaymentMapper.toDomain(payment)).toList());
+		orderResponseDTO.setPerson(person);
+		orderResponseDTO.setAwaitingTime(order.getAwaitingTime());
+		orderResponseDTO.setTotalPrice(order.getTotalPrice());
+        kitchen.ifPresent(value -> orderResponseDTO.setKitchenQueue(KitchenMapper.toDTO(value)));
+		return orderResponseDTO;
 	}
 
 	public static OrderResponseDTO toDTO(Order order) {

--- a/project/src/main/java/tech/fiap/project/app/controller/KitchenController.java
+++ b/project/src/main/java/tech/fiap/project/app/controller/KitchenController.java
@@ -25,4 +25,14 @@ public class KitchenController {
 		return kitchenService.findById(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
 	}
 
+	@PutMapping("/{id}/production")
+	public ResponseEntity<KitchenDTO> production(@PathVariable Long id) {
+		return kitchenService.setInProduction(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+	}
+
+	@PutMapping("/{id}/done")
+	public ResponseEntity<KitchenDTO> done(@PathVariable Long id) {
+		return kitchenService.setDone(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+	}
+
 }

--- a/project/src/main/java/tech/fiap/project/app/controller/OrderController.java
+++ b/project/src/main/java/tech/fiap/project/app/controller/OrderController.java
@@ -8,10 +8,7 @@ import tech.fiap.project.app.dto.KitchenDTO;
 import tech.fiap.project.app.dto.OrderRequestDTO;
 import tech.fiap.project.app.dto.OrderResponseDTO;
 import tech.fiap.project.app.service.kitchen.KitchenService;
-import tech.fiap.project.app.service.order.CheckoutOrderService;
-import tech.fiap.project.app.service.order.CreateOrderService;
-import tech.fiap.project.app.service.order.EndOrderService;
-import tech.fiap.project.app.service.order.RetrieveOrderService;
+import tech.fiap.project.app.service.order.*;
 
 import java.awt.image.BufferedImage;
 import java.util.List;
@@ -31,6 +28,8 @@ public class OrderController {
 	private CheckoutOrderService checkoutOrderService;
 
 	private KitchenService kitchenService;
+
+	private DeliverOrderService deliverOrderService;
 
 	@PostMapping
 	public ResponseEntity<OrderResponseDTO> createOrUpdate(@RequestBody OrderRequestDTO orderRequestDTO) {
@@ -65,4 +64,14 @@ public class OrderController {
 		return ResponseEntity.notFound().build();
 	}
 
+	@GetMapping(value = "/ongoing/orders")
+	public ResponseEntity<List<OrderResponseDTO>> ongoingOrders() {
+		return ResponseEntity.ok(retrieveOrderService.findOngoingAll());
+	}
+
+	@PutMapping(value = "/deliver/{id}")
+	public ResponseEntity<OrderResponseDTO> deliver(@PathVariable Long id) {
+		OrderResponseDTO deliveredOrder = deliverOrderService.execute(id);
+		return ResponseEntity.ok(deliveredOrder);
+	}
 }

--- a/project/src/main/java/tech/fiap/project/app/dto/KitchenDTO.java
+++ b/project/src/main/java/tech/fiap/project/app/dto/KitchenDTO.java
@@ -17,6 +17,8 @@ public class KitchenDTO {
 
 	private LocalDateTime creationDate;
 
+	private LocalDateTime updatedDate;
+
 	private KitchenStatus status;
 
 }

--- a/project/src/main/java/tech/fiap/project/app/service/kitchen/KitchenService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/kitchen/KitchenService.java
@@ -28,7 +28,7 @@ public class KitchenService {
 
 	public Optional<KitchenDTO> create(OrderResponseDTO order) {
 		var now = LocalDateTime.now();
-		var kitchen = new Kitchen(order.getId(), now, KitchenStatus.AWAITING_PRODUCTION);
+		var kitchen = new Kitchen(order.getId(), now, now, KitchenStatus.AWAITING_PRODUCTION);
 
 		Kitchen createdKitchen = createUseCase.execute(kitchen);
 		return Optional.ofNullable(KitchenMapper.toDTO(createdKitchen));

--- a/project/src/main/java/tech/fiap/project/app/service/kitchen/KitchenService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/kitchen/KitchenService.java
@@ -1,6 +1,7 @@
 package tech.fiap.project.app.service.kitchen;
 
 import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import tech.fiap.project.app.adapter.KitchenMapper;
 import tech.fiap.project.app.dto.KitchenDTO;
@@ -9,6 +10,7 @@ import tech.fiap.project.app.dto.OrderResponseDTO;
 import tech.fiap.project.domain.entity.*;
 import tech.fiap.project.domain.usecase.kitchen.KitchenCreateUseCase;
 import tech.fiap.project.domain.usecase.kitchen.KitchenRetrieveUseCase;
+import tech.fiap.project.domain.usecase.kitchen.KitchenUpdateUseCase;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,12 +24,46 @@ public class KitchenService {
 
 	private KitchenCreateUseCase createUseCase;
 
+	private KitchenUpdateUseCase updateUseCase;
+
 	public Optional<KitchenDTO> create(OrderResponseDTO order) {
 		var now = LocalDateTime.now();
 		var kitchen = new Kitchen(order.getId(), now, KitchenStatus.AWAITING_PRODUCTION);
 
 		Kitchen createdKitchen = createUseCase.execute(kitchen);
 		return Optional.ofNullable(KitchenMapper.toDTO(createdKitchen));
+	}
+
+	public Optional<KitchenDTO> setInProduction(Long id) {
+		var now = LocalDateTime.now();
+		Optional<Kitchen> kitchen = retrieveUseCase.findById(id);
+
+		if (kitchen.isPresent()) {
+			var safeKitchen = kitchen.get();
+			safeKitchen.setStatus(KitchenStatus.IN_PRODUCTION);
+			safeKitchen.setUpdatedDate(now);
+
+			Kitchen updatedKitchen = updateUseCase.execute(safeKitchen);
+			return Optional.ofNullable(KitchenMapper.toDTO(updatedKitchen));
+		}
+
+		return Optional.empty();
+	}
+
+	public Optional<KitchenDTO> setDone(Long id) {
+		var now = LocalDateTime.now();
+		Optional<Kitchen> kitchen = retrieveUseCase.findById(id);
+
+		if (kitchen.isPresent()) {
+			var safeKitchen = kitchen.get();
+			safeKitchen.setStatus(KitchenStatus.DONE);
+			safeKitchen.setUpdatedDate(now);
+
+			Kitchen updatedKitchen = updateUseCase.execute(safeKitchen);
+			return Optional.ofNullable(KitchenMapper.toDTO(updatedKitchen));
+		}
+
+		return Optional.empty();
 	}
 
 	public List<KitchenDTO> findAll() {

--- a/project/src/main/java/tech/fiap/project/app/service/order/CheckoutOrderService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/order/CheckoutOrderService.java
@@ -17,8 +17,8 @@ public class CheckoutOrderService {
 	private RetrieveOrderUseCase retrieveOrderUseCase;
 
 	public Optional<OrderResponseDTO> execute(Long id) {
-		Optional<Order> order = retrieveOrderUseCase.findById(id);
-		if (order.isPresent() && order.get().getStatus().equals(OrderStatus.AWAITING_PAYMENT)) {
+		Optional<Order> order = retrieveOrderUseCase.findByIdWithPayment(id);
+		if (order.isPresent() && order.get().getStatus().equals(OrderStatus.PAID)) {
 			return order.map(OrderMapper::toDTO);
 		}
 		return Optional.empty();

--- a/project/src/main/java/tech/fiap/project/app/service/order/DeliverOrderService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/order/DeliverOrderService.java
@@ -2,11 +2,15 @@ package tech.fiap.project.app.service.order;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import tech.fiap.project.app.adapter.KitchenMapper;
 import tech.fiap.project.app.adapter.OrderMapper;
+import tech.fiap.project.app.dto.KitchenDTO;
 import tech.fiap.project.app.dto.OrderResponseDTO;
+import tech.fiap.project.domain.entity.Kitchen;
 import tech.fiap.project.domain.entity.KitchenStatus;
 import tech.fiap.project.domain.entity.Order;
 import tech.fiap.project.domain.entity.OrderStatus;
+import tech.fiap.project.domain.usecase.kitchen.KitchenRetrieveUseCase;
 import tech.fiap.project.domain.usecase.order.DeliverOrderUseCase;
 import tech.fiap.project.domain.usecase.order.EndOrderUseCase;
 import tech.fiap.project.domain.usecase.order.RetrieveOrderUseCase;
@@ -24,13 +28,16 @@ public class DeliverOrderService {
 
 	private DeliverOrderUseCase deliverOrderUseCase;
 	private RetrieveOrderUseCase retrieveOrderUseCase;
+	private KitchenRetrieveUseCase kitchenRetrieveUseCase;
 
 	public OrderResponseDTO execute(Long id) {
 		return OrderMapper.toResponse(deliverOrder(id));
 	}
 
 	private Order deliverOrder(Long id) {
-		Optional<OrderResponseDTO> orderDTO = retrieveOrderUseCase.findById(id).map(OrderMapper::toDTO);
+		Optional<Kitchen> kitchen = kitchenRetrieveUseCase.findById(id);
+		Optional<OrderResponseDTO> orderDTO = retrieveOrderUseCase.findByIdWithPayment(id).map(_order -> OrderMapper.toDTO(_order, kitchen));
+
 		if (orderDTO.isPresent()) {
 			var safeOrder = orderDTO.get();
 			var safeKitchen = safeOrder.getKitchenQueue();

--- a/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
@@ -5,13 +5,18 @@ import org.springframework.stereotype.Service;
 import tech.fiap.project.app.adapter.OrderMapper;
 import tech.fiap.project.app.dto.OrderRequestDTO;
 import tech.fiap.project.app.dto.OrderResponseDTO;
+import tech.fiap.project.domain.entity.KitchenStatus;
+import tech.fiap.project.domain.entity.OrderStatus;
 import tech.fiap.project.domain.usecase.order.RetrieveOrderUseCase;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -31,9 +36,51 @@ public class RetrieveOrderService {
 		return orderDTO;
 	}
 
+	public List<OrderResponseDTO> findOngoingAll() {
+		List<OrderResponseDTO> dto = findAll();
+		return sortByStatusThanDate(dto);
+	}
+
 	private void setDuration(OrderResponseDTO order) {
 		long seconds = Duration.between(order.getCreatedDate(), LocalDateTime.now()).getSeconds();
 		order.setAwaitingTime(Duration.of(seconds, ChronoUnit.SECONDS));
 	}
 
+	private List<OrderResponseDTO> sortByStatusThanDate(List<OrderResponseDTO> listOrder) {
+		List<OrderResponseDTO> filteredListOrder = filterOngoingListOrder(listOrder);
+        return sortOngoingListOrder(filteredListOrder);
+	}
+
+	private List<OrderResponseDTO> filterOngoingListOrder(List<OrderResponseDTO> listOrder) {
+        return listOrder.stream()
+				.filter((order) -> (order.getKitchenQueue() != null && order.getStatus() != OrderStatus.FINISHED))
+				.collect(Collectors.toList());
+	}
+
+	private List<OrderResponseDTO> sortOngoingListOrder(List<OrderResponseDTO> listOrder) {
+        listOrder
+				.sort((order1, order2) -> {
+					int statusComparison = priorityCompare(order1, order2);
+					if (statusComparison != 0) {
+						return statusComparison;
+					}
+					return order1.getUpdatedDate().compareTo(order2.getUpdatedDate());
+				});
+		return listOrder;
+	}
+
+	private Integer priorityCompare(OrderResponseDTO firstOrder, OrderResponseDTO secondOrder) {
+		Map<KitchenStatus, Integer> priorityStatus = getPriorityOrderStatus();
+		KitchenStatus firstOrderStatus = firstOrder.getKitchenQueue().getStatus();
+		KitchenStatus secondOrderStatus = secondOrder.getKitchenQueue().getStatus();
+		return priorityStatus.get(firstOrderStatus).compareTo(priorityStatus.get(secondOrderStatus));
+	}
+
+	private Map<KitchenStatus, Integer> getPriorityOrderStatus() {
+		Map<KitchenStatus, Integer> statusOrder = new HashMap<>();
+		statusOrder.put(KitchenStatus.AWAITING_PRODUCTION, 1);
+		statusOrder.put(KitchenStatus.IN_PRODUCTION, 2);
+		statusOrder.put(KitchenStatus.DONE, 3);
+		return statusOrder;
+	}
 }

--- a/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
@@ -3,10 +3,14 @@ package tech.fiap.project.app.service.order;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import tech.fiap.project.app.adapter.OrderMapper;
+import tech.fiap.project.app.dto.KitchenDTO;
 import tech.fiap.project.app.dto.OrderRequestDTO;
 import tech.fiap.project.app.dto.OrderResponseDTO;
+import tech.fiap.project.domain.entity.Kitchen;
 import tech.fiap.project.domain.entity.KitchenStatus;
 import tech.fiap.project.domain.entity.OrderStatus;
+import tech.fiap.project.domain.usecase.kitchen.KitchenRetrieveUseCase;
+import tech.fiap.project.domain.usecase.kitchen.KitchenUpdateUseCase;
 import tech.fiap.project.domain.usecase.order.RetrieveOrderUseCase;
 
 import java.time.Duration;
@@ -23,6 +27,7 @@ import java.util.stream.Collectors;
 public class RetrieveOrderService {
 
 	private RetrieveOrderUseCase retrieveOrderUseCase;
+	private KitchenRetrieveUseCase kitchenRetrieveUseCase;
 
 	public List<OrderResponseDTO> findAll() {
 		List<OrderResponseDTO> dto = OrderMapper.toDTO(retrieveOrderUseCase.findAll());

--- a/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
+++ b/project/src/main/java/tech/fiap/project/app/service/order/RetrieveOrderService.java
@@ -42,7 +42,10 @@ public class RetrieveOrderService {
 	}
 
 	public List<OrderResponseDTO> findOngoingAll() {
-		List<OrderResponseDTO> dto = findAll();
+		List<Kitchen> kitchenDto = kitchenRetrieveUseCase.findAll();
+		List<Long> kichenIds = kitchenDto.stream().map(_kitchen -> _kitchen.getOrderId()).toList();
+		List<OrderResponseDTO> dto = OrderMapper.toDTO(retrieveOrderUseCase.findAllById(kichenIds), kitchenDto);
+
 		return sortByStatusThanDate(dto);
 	}
 
@@ -56,7 +59,9 @@ public class RetrieveOrderService {
         return sortOngoingListOrder(filteredListOrder);
 	}
 
-	private List<OrderResponseDTO> filterOngoingListOrder(List<OrderResponseDTO> listOrder) {
+	private List<OrderResponseDTO> filterOngoingListOrder(
+			List<OrderResponseDTO> listOrder
+	) {
         return listOrder.stream()
 				.filter((order) -> (order.getKitchenQueue() != null && order.getStatus() != OrderStatus.FINISHED))
 				.collect(Collectors.toList());

--- a/project/src/main/java/tech/fiap/project/domain/dataprovider/KitchenDataProvider.java
+++ b/project/src/main/java/tech/fiap/project/domain/dataprovider/KitchenDataProvider.java
@@ -12,6 +12,8 @@ public interface KitchenDataProvider {
 
 	Kitchen create(Kitchen kitchen);
 
+	Kitchen update(Kitchen kitchen);
+
 	Optional<Kitchen> retrieveById(Long orderId);
 
 }

--- a/project/src/main/java/tech/fiap/project/domain/dataprovider/KitchenDataProvider.java
+++ b/project/src/main/java/tech/fiap/project/domain/dataprovider/KitchenDataProvider.java
@@ -10,6 +10,8 @@ public interface KitchenDataProvider {
 
 	List<Kitchen> retrieveAll();
 
+	List<Kitchen> retrieveAllIds(List<Long> orderIds);
+
 	Kitchen create(Kitchen kitchen);
 
 	Kitchen update(Kitchen kitchen);

--- a/project/src/main/java/tech/fiap/project/domain/dataprovider/OrderDataProvider.java
+++ b/project/src/main/java/tech/fiap/project/domain/dataprovider/OrderDataProvider.java
@@ -11,6 +11,8 @@ public interface OrderDataProvider {
 
 	List<Order> retrieveAll();
 
+	List<Order> retrieveAllById(List<Long> id);
+
 	Order create(Order order);
 
 	Optional<Order> retrieveById(Long id);

--- a/project/src/main/java/tech/fiap/project/domain/entity/Kitchen.java
+++ b/project/src/main/java/tech/fiap/project/domain/entity/Kitchen.java
@@ -18,10 +18,10 @@ public class Kitchen {
 
 	private KitchenStatus status;
 
-	public Kitchen(Long orderId, LocalDateTime creationDate, KitchenStatus status) {
+	public Kitchen(Long orderId, LocalDateTime creationDate, LocalDateTime updatedDate, KitchenStatus status) {
 		this.orderId = orderId;
 		this.creationDate = creationDate;
-		this.updatedDate = creationDate;
+		this.updatedDate = updatedDate;
 		this.status = status;
 	}
 

--- a/project/src/main/java/tech/fiap/project/domain/entity/Kitchen.java
+++ b/project/src/main/java/tech/fiap/project/domain/entity/Kitchen.java
@@ -14,11 +14,14 @@ public class Kitchen {
 
 	private LocalDateTime creationDate;
 
+	private LocalDateTime updatedDate;
+
 	private KitchenStatus status;
 
 	public Kitchen(Long orderId, LocalDateTime creationDate, KitchenStatus status) {
 		this.orderId = orderId;
 		this.creationDate = creationDate;
+		this.updatedDate = creationDate;
 		this.status = status;
 	}
 
@@ -44,6 +47,14 @@ public class Kitchen {
 
 	public void setStatus(KitchenStatus status) {
 		this.status = status;
+	}
+
+	public LocalDateTime getUpdatedDate() {
+		return updatedDate;
+	}
+
+	public void setUpdatedDate(LocalDateTime updatedDate) {
+		this.updatedDate = updatedDate;
 	}
 
 }

--- a/project/src/main/java/tech/fiap/project/domain/entity/OrderStatus.java
+++ b/project/src/main/java/tech/fiap/project/domain/entity/OrderStatus.java
@@ -2,6 +2,6 @@ package tech.fiap.project.domain.entity;
 
 public enum OrderStatus {
 
-	PENDING, AWAITING_PAYMENT, PAID, CANCELED
+	PENDING, AWAITING_PAYMENT, PAID, CANCELED, FINISHED
 
 }

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/kitchen/KitchenRetrieveUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/kitchen/KitchenRetrieveUseCaseImpl.java
@@ -27,6 +27,11 @@ public class KitchenRetrieveUseCaseImpl implements KitchenRetrieveUseCase {
 	}
 
 	@Override
+	public List<Kitchen> findIds(List<Long> orderIds) {
+		return kitchenDataProvider.retrieveAll();
+	}
+
+	@Override
 	public Optional<Kitchen> findById(Long orderId) {
 		return kitchenDataProvider.retrieveById(orderId);
 	}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/kitchen/KitchenUpdateUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/kitchen/KitchenUpdateUseCaseImpl.java
@@ -1,0 +1,21 @@
+package tech.fiap.project.domain.usecase.impl.kitchen;
+
+import tech.fiap.project.domain.dataprovider.KitchenDataProvider;
+import tech.fiap.project.domain.entity.Kitchen;
+import tech.fiap.project.domain.usecase.kitchen.KitchenCreateUseCase;
+import tech.fiap.project.domain.usecase.kitchen.KitchenUpdateUseCase;
+
+public class KitchenUpdateUseCaseImpl implements KitchenUpdateUseCase {
+
+	private final KitchenDataProvider kitchenDataProvider;
+
+	public KitchenUpdateUseCaseImpl(KitchenDataProvider kitchenDataProvider) {
+		this.kitchenDataProvider = kitchenDataProvider;
+	}
+
+	@Override
+	public Kitchen execute(Kitchen kitchen) {
+		return kitchenDataProvider.create(kitchen);
+	}
+
+}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/DeliverOrderUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/DeliverOrderUseCaseImpl.java
@@ -25,9 +25,9 @@ public class DeliverOrderUseCaseImpl implements DeliverOrderUseCase {
 	}
 
 	private Order deliverOrder(Long id) {
-		Optional<Order> orderSaved = retrieveOrderUseCase.findById(id);
+		Optional<Order> orderSaved = retrieveOrderUseCase.findByIdWithPayment(id);
 		if (orderSaved.isPresent()) {
-			if (orderSaved.get().getStatus() != OrderStatus.FINISHED) {
+			if (orderSaved.get().getStatus() == OrderStatus.FINISHED) {
 				throw new OrderNotFound(id);
 			}
 			Order order = orderSaved.get();

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/DeliverOrderUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/DeliverOrderUseCaseImpl.java
@@ -1,0 +1,41 @@
+package tech.fiap.project.domain.usecase.impl.order;
+
+import tech.fiap.project.domain.entity.Order;
+import tech.fiap.project.domain.entity.OrderStatus;
+import tech.fiap.project.domain.usecase.order.CreateOrUpdateOrderUseCase;
+import tech.fiap.project.domain.usecase.order.DeliverOrderUseCase;
+import tech.fiap.project.domain.usecase.order.RetrieveOrderUseCase;
+import tech.fiap.project.infra.exception.OrderNotFound;
+import tech.fiap.project.infra.exception.OrderStatusException;
+
+import java.util.Optional;
+
+public class DeliverOrderUseCaseImpl implements DeliverOrderUseCase {
+	private final CreateOrUpdateOrderUseCase createOrUpdateOrderUsecase;
+	private final RetrieveOrderUseCase retrieveOrderUseCase;
+
+    public DeliverOrderUseCaseImpl(CreateOrUpdateOrderUseCase createOrUpdateOrderUsecase, RetrieveOrderUseCase retrieveOrderUseCase) {
+        this.createOrUpdateOrderUsecase = createOrUpdateOrderUsecase;
+        this.retrieveOrderUseCase = retrieveOrderUseCase;
+    }
+
+    @Override
+	public Order execute(Long id) {
+		return deliverOrder(id);
+	}
+
+	private Order deliverOrder(Long id) {
+		Optional<Order> orderSaved = retrieveOrderUseCase.findById(id);
+		if (orderSaved.isPresent()) {
+			if (orderSaved.get().getStatus() != OrderStatus.FINISHED) {
+				throw new OrderNotFound(id);
+			}
+			Order order = orderSaved.get();
+			order.setStatus(OrderStatus.FINISHED);
+			return createOrUpdateOrderUsecase.execute(order);
+		}
+		else {
+			throw new OrderStatusException(id);
+		}
+	}
+}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/RetrieveOrderUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/RetrieveOrderUseCaseImpl.java
@@ -21,6 +21,11 @@ public class RetrieveOrderUseCaseImpl implements RetrieveOrderUseCase {
 	}
 
 	@Override
+	public List<Order> findAllById(List<Long> ids) {
+		return orderDataProvider.retrieveAll();
+	}
+
+	@Override
 	public Optional<Order> findById(Long id) {
 		return orderDataProvider.retrieveById(id);
 	}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/RetrieveOrderUseCaseImpl.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/impl/order/RetrieveOrderUseCaseImpl.java
@@ -25,4 +25,8 @@ public class RetrieveOrderUseCaseImpl implements RetrieveOrderUseCase {
 		return orderDataProvider.retrieveById(id);
 	}
 
+	@Override
+	public Optional<Order> findByIdWithPayment(Long id) {
+		return orderDataProvider.retrieveByIdWithPayment(id);
+	}
 }

--- a/project/src/main/java/tech/fiap/project/domain/usecase/kitchen/KitchenRetrieveUseCase.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/kitchen/KitchenRetrieveUseCase.java
@@ -11,4 +11,5 @@ public interface KitchenRetrieveUseCase {
 
 	Optional<Kitchen> findById(Long orderId);
 
+	List<Kitchen> findIds(List<Long> orderIds);
 }

--- a/project/src/main/java/tech/fiap/project/domain/usecase/kitchen/KitchenUpdateUseCase.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/kitchen/KitchenUpdateUseCase.java
@@ -1,0 +1,9 @@
+package tech.fiap.project.domain.usecase.kitchen;
+
+import tech.fiap.project.domain.entity.Kitchen;
+
+public interface KitchenUpdateUseCase {
+
+	Kitchen execute(Kitchen kitchen);
+
+}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/order/DeliverOrderUseCase.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/order/DeliverOrderUseCase.java
@@ -1,0 +1,9 @@
+package tech.fiap.project.domain.usecase.order;
+
+import tech.fiap.project.domain.entity.Order;
+
+public interface DeliverOrderUseCase {
+
+	Order execute(Long id);
+
+}

--- a/project/src/main/java/tech/fiap/project/domain/usecase/order/RetrieveOrderUseCase.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/order/RetrieveOrderUseCase.java
@@ -11,4 +11,6 @@ public interface RetrieveOrderUseCase {
 
 	Optional<Order> findById(Long id);
 
+	Optional<Order> findByIdWithPayment(Long id);
+
 }

--- a/project/src/main/java/tech/fiap/project/domain/usecase/order/RetrieveOrderUseCase.java
+++ b/project/src/main/java/tech/fiap/project/domain/usecase/order/RetrieveOrderUseCase.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface RetrieveOrderUseCase {
 
 	List<Order> findAll();
+	List<Order> findAllById(List<Long> ids);
 
 	Optional<Order> findById(Long id);
 

--- a/project/src/main/java/tech/fiap/project/infra/configuration/Configuration.java
+++ b/project/src/main/java/tech/fiap/project/infra/configuration/Configuration.java
@@ -20,7 +20,9 @@ import tech.fiap.project.domain.usecase.impl.item.RetrieveItemUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.item.CreateOrUpdateOrderUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.kitchen.KitchenCreateUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.kitchen.KitchenRetrieveUseCaseImpl;
+import tech.fiap.project.domain.usecase.impl.kitchen.KitchenUpdateUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.order.CalculateTotalOrderUseCaseImpl;
+import tech.fiap.project.domain.usecase.impl.order.DeliverOrderUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.order.EndOrderUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.order.RetrieveOrderUseCaseImpl;
 import tech.fiap.project.domain.usecase.impl.payment.ConfirmPaymentUseCaseImpl;
@@ -30,7 +32,9 @@ import tech.fiap.project.domain.usecase.impl.person.*;
 import tech.fiap.project.domain.usecase.item.InitializeItemUseCase;
 import tech.fiap.project.domain.usecase.kitchen.KitchenCreateUseCase;
 import tech.fiap.project.domain.usecase.kitchen.KitchenRetrieveUseCase;
+import tech.fiap.project.domain.usecase.kitchen.KitchenUpdateUseCase;
 import tech.fiap.project.domain.usecase.order.CreateOrUpdateOrderUseCase;
+import tech.fiap.project.domain.usecase.order.DeliverOrderUseCase;
 import tech.fiap.project.domain.usecase.order.EndOrderUseCase;
 import tech.fiap.project.domain.usecase.payment.ConfirmPaymentUseCase;
 import tech.fiap.project.domain.usecase.payment.RejectPaymentUseCase;
@@ -146,6 +150,12 @@ public class Configuration {
 	}
 
 	@Bean
+	public DeliverOrderUseCase deliverOrderUseCase(CreateOrUpdateOrderUseCase createOrUpdateOrderUseCase,
+												   RetrieveOrderUseCaseImpl retrieveOrderUseCase) {
+		return new DeliverOrderUseCaseImpl(createOrUpdateOrderUseCase, retrieveOrderUseCase);
+	}
+
+	@Bean
 	public KitchenRetrieveUseCase kitchenRetrieveUseCase(KitchenDataProvider kitchenDataProvider) {
 		return new KitchenRetrieveUseCaseImpl(kitchenDataProvider);
 	}
@@ -153,6 +163,11 @@ public class Configuration {
 	@Bean
 	public KitchenCreateUseCase kitchenCreateUseCase(KitchenDataProvider kitchenDataProvider) {
 		return new KitchenCreateUseCaseImpl(kitchenDataProvider);
+	}
+
+	@Bean
+	public KitchenUpdateUseCase kitchenUpdateUseCase(KitchenDataProvider kitchenDataProvider) {
+		return new KitchenUpdateUseCaseImpl(kitchenDataProvider);
 	}
 
 	@Bean

--- a/project/src/main/java/tech/fiap/project/infra/dataprovider/KitchenDataProviderImpl.java
+++ b/project/src/main/java/tech/fiap/project/infra/dataprovider/KitchenDataProviderImpl.java
@@ -33,6 +33,12 @@ public class KitchenDataProviderImpl implements KitchenDataProvider {
 		KitchenEntity kitchenSaved = kitchenRepository.save(entity);
 		return KitchenRepositoryMapper.toDomain(kitchenSaved);
 	}
+	@Override
+	public Kitchen update(Kitchen kitchen) {
+		KitchenEntity entity = KitchenRepositoryMapper.toEntity(kitchen);
+		KitchenEntity kitchenSaved = kitchenRepository.save(entity);
+		return KitchenRepositoryMapper.toDomain(kitchenSaved);
+	}
 
 	@Override
 	public Optional<Kitchen> retrieveById(Long orderId) {

--- a/project/src/main/java/tech/fiap/project/infra/dataprovider/KitchenDataProviderImpl.java
+++ b/project/src/main/java/tech/fiap/project/infra/dataprovider/KitchenDataProviderImpl.java
@@ -28,6 +28,11 @@ public class KitchenDataProviderImpl implements KitchenDataProvider {
 	}
 
 	@Override
+	public List<Kitchen> retrieveAllIds(List<Long> orderIds) {
+		return KitchenRepositoryMapper.toDomain(kitchenRepository.findAllById(orderIds));
+	}
+
+	@Override
 	public Kitchen create(Kitchen kitchen) {
 		KitchenEntity entity = KitchenRepositoryMapper.toEntity(kitchen);
 		KitchenEntity kitchenSaved = kitchenRepository.save(entity);

--- a/project/src/main/java/tech/fiap/project/infra/dataprovider/OrderDataProviderImpl.java
+++ b/project/src/main/java/tech/fiap/project/infra/dataprovider/OrderDataProviderImpl.java
@@ -39,6 +39,11 @@ public class OrderDataProviderImpl implements OrderDataProvider {
 	}
 
 	@Override
+	public List<Order> retrieveAllById(List<Long> id) {
+		return OrderRepositoryMapper.toDomain(orderRepository.findAllById(id));
+	}
+
+	@Override
 	public Order create(Order order) {
 
 		OrderEntity entity = OrderRepositoryMapper.toEntityWithoutPayment(order);

--- a/project/src/main/java/tech/fiap/project/infra/entity/KitchenEntity.java
+++ b/project/src/main/java/tech/fiap/project/infra/entity/KitchenEntity.java
@@ -19,6 +19,9 @@ public class KitchenEntity {
 	@JoinColumn(name = "creation_date")
 	private LocalDateTime creationDate;
 
+	@JoinColumn(name = "updated_date")
+	private LocalDateTime updatedDate;
+
 	@Enumerated(EnumType.STRING)
 	private KitchenStatus status;
 

--- a/project/src/main/java/tech/fiap/project/infra/entity/KitchenEntity.java
+++ b/project/src/main/java/tech/fiap/project/infra/entity/KitchenEntity.java
@@ -2,7 +2,6 @@ package tech.fiap.project.infra.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
-import tech.fiap.project.domain.entity.DocumentType;
 import tech.fiap.project.domain.entity.KitchenStatus;
 
 import java.time.LocalDateTime;

--- a/project/src/main/java/tech/fiap/project/infra/exception/KitchenStatusException.java
+++ b/project/src/main/java/tech/fiap/project/infra/exception/KitchenStatusException.java
@@ -1,0 +1,11 @@
+package tech.fiap.project.infra.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class KitchenStatusException extends BusinessException {
+
+	public KitchenStatusException(Long orderId) {
+		super("order.kitchen.status.exception", HttpStatus.BAD_REQUEST, null, orderId.toString());
+	}
+
+}

--- a/project/src/main/java/tech/fiap/project/infra/exception/OrderStatusException.java
+++ b/project/src/main/java/tech/fiap/project/infra/exception/OrderStatusException.java
@@ -1,0 +1,11 @@
+package tech.fiap.project.infra.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class OrderStatusException extends BusinessException {
+
+	public OrderStatusException(Long orderId) {
+		super("order.status.exception", HttpStatus.BAD_REQUEST, null, orderId.toString());
+	}
+
+}

--- a/project/src/main/java/tech/fiap/project/infra/mapper/KitchenRepositoryMapper.java
+++ b/project/src/main/java/tech/fiap/project/infra/mapper/KitchenRepositoryMapper.java
@@ -22,6 +22,7 @@ public class KitchenRepositoryMapper {
 		else {
 			KitchenEntity kitchenEntity = new KitchenEntity();
 			kitchenEntity.setCreationDate(kitchen.getCreationDate());
+			kitchenEntity.setUpdatedDate(kitchen.getUpdatedDate());
 			kitchenEntity.setStatus(kitchen.getStatus());
 			kitchenEntity.setOrderId(kitchen.getOrderId());
 			return kitchenEntity;
@@ -33,7 +34,7 @@ public class KitchenRepositoryMapper {
 			return null;
 		}
 		else {
-			return new Kitchen(kitchenEntity.getOrderId(), kitchenEntity.getCreationDate(), kitchenEntity.getStatus());
+			return new Kitchen(kitchenEntity.getOrderId(), kitchenEntity.getCreationDate(), kitchenEntity.getUpdatedDate(), kitchenEntity.getStatus());
 		}
 	}
 

--- a/project/src/main/resources/db/changelog/db.changelog-0.0.4.xml
+++ b/project/src/main/resources/db/changelog/db.changelog-0.0.4.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="1" author="matheus.sanada">
+        <addColumn tableName="kitchen">
+            <column name="updated_date" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/project/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/project/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
     <include file="db/changelog/db.changelog-0.0.1.xml"/>
     <include file="db/changelog/db.changelog-0.0.2.xml"/>
     <include file="db/changelog/db.changelog-0.0.3.xml"/>
+    <include file="db/changelog/db.changelog-0.0.4.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
- Adicionar status, tanto na fila da cozinha, quanto na ordem
- Adicionar chamada para mudar o status da cozinha
- Adicionar chamada para a entrega do pedido, que nesse caso não deve mais mostrar na lista
- Para um pedido poder ser entregue ele tem que estar finalizado pela cozinha
- Listagem dos pedidos em andamento